### PR TITLE
[FIX] Add Microsoft.CSharp package for dynamic support

### DIFF
--- a/QuickbaseNet/QuickbaseNet.csproj
+++ b/QuickbaseNet/QuickbaseNet.csproj
@@ -1,15 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net48</TargetFrameworks>
-    <IsPublishable>True</IsPublishable>
-	<InternalsVisibleTo>QuickbaseNet.UnitTests</InternalsVisibleTo>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net48</TargetFrameworks>
+		<IsPublishable>True</IsPublishable>
+		<InternalsVisibleTo>QuickbaseNet.UnitTests</InternalsVisibleTo>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	</ItemGroup>
+
+	<!-- Conditionally include Microsoft.CSharp for frameworks that require it -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+	</ItemGroup>
 
 	<PropertyGroup>
 		<PackageId>QuickbaseNet</PackageId>


### PR DESCRIPTION
To resolve the CS0656 compiler error encountered when using dynamic features in target frameworks netstandard2.0, netstandard2.1, and net48.